### PR TITLE
fix: add fullpath custom prop 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ import {
  * @param item: DataTransferItem
  * @param options (optional)
  *  {options.recursive} (default: false) - whether to recursively follow the dir structure
+ *  {options.withFullPath} (default: false) - whether to include the full path in the file entry
  *  {options.bail} (default: 1000) - how many levels to follow recursively before bailing
  */
 const getFiles = (item, options = {}) =>
@@ -35,6 +36,7 @@ const getDataTransferItemFiles = (item, options) =>
  * @param evt: DragEvent - containing dataTransfer
  * @param options (optional)
  *  {options.recursive} (default: false) - whether to recursively follow the dir structure
+ *  {options.withFullPath} (default: false) - whether to include the full path in the file entry
  *  {options.bail} (default: 1000) - how many levels to follow recursively before bailing
  */
 const getFilesFromDragEvent = (evt, options = {}) => {

--- a/lib/tests/utils.test.js
+++ b/lib/tests/utils.test.js
@@ -41,11 +41,11 @@ describe("utils tests", () => {
     describe("isItemFileEntry tests", () => {
 
         it("should return true for file kind", () => {
-            expect(utils.isItemFileEntry({kind: "file"})).toBe(true);
+            expect(utils.isItemFileEntry({ kind: "file" })).toBe(true);
         });
 
         it("should return false for non file kind", () => {
-            expect(utils.isItemFileEntry({kind: "text"})).toBe(false);
+            expect(utils.isItemFileEntry({ kind: "text" })).toBe(false);
         });
     });
 
@@ -75,14 +75,14 @@ describe("utils tests", () => {
             expect(utils.initOptions(options)).toBe(options);
         });
 
-        it("should work with boolean true", ()=>{
+        it("should work with boolean true", () => {
             const options = utils.initOptions(true);
 
             expect(options.recursive).toBe(true);
             expect(options.bail).toBe(1000);
         });
 
-        it("should work with boolean false", ()=>{
+        it("should work with boolean false", () => {
             const options = utils.initOptions(false);
 
             expect(options.recursive).toBe(false);
@@ -94,29 +94,29 @@ describe("utils tests", () => {
 
         it("should return the file object", async () => {
 
-            const file = {name: 1};
+            const file = { name: 1 };
 
             const result = await utils.getFileFromFileEntry(
-                {file: (resolve) => resolve(file)});
+                { file: (resolve) => resolve(file) });
 
             expect(result).toBe(file);
         });
 
         it("should return the file object with full path", async () => {
-
-            const file = {name: 1};
+            const fullPath = "a/b/c";
+            const file = { name: 1 };
 
             const result = await utils.getFileFromFileEntry(
-                {file: (resolve) => resolve(file), fullPath: 'a/b/c'},
-                {withFullPath: true});
+                { file: (resolve) => resolve(file), fullPath },
+                { withFullPath: true });
 
-            expect(result).toEqual({name: 'a/b/c'});
+            expect(result).toEqual({ name: fullPath, hdcFullPath: fullPath });
         });
 
         it("should swallow error", async () => {
 
             const result = await utils.getFileFromFileEntry(
-                {file: (resolve, reject) => reject()});
+                { file: (resolve, reject) => reject() });
 
             expect(result).toBe(null);
         });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,12 +7,20 @@ const initOptions = (options) => options[OPTS_SYM] === true ?
         [OPTS_SYM]: true,
         recursive: options === true || !!options.recursive,
         withFullPath: !!options.withFullPath,
-        bail: (options.bail && options.bail > 0) ? options.bail : BAIL_LEVEL,
+        bail: (options.bail && options.bail > 0) ? options.bail : BAIL_LEVEL
     };
 
+const getFileWithFullPath = (file, fullPath) => {
+    const newFile = new File([file], fullPath,{ type: file.type, lastModified: file.lastModified });
+    //we add "hdcFullPath" prop because firefox converts the path "/" delimiter into ":"
+    newFile.hdcFullPath = fullPath;
+    return newFile;
+};
 
-const getFile = (file, fullPath, {withFullPath = false} = {}) => withFullPath ?
-    new File([file], fullPath, {type: file.type}) : file;
+const getFile = (file, fullPath, options = {}) =>
+    options.withFullPath ?
+        getFileWithFullPath(file, fullPath, options) :
+        file;
 
 const getFileFromFileEntry = (entry, options) =>
     new Promise((resolve, reject) => {

--- a/test/index.html
+++ b/test/index.html
@@ -28,7 +28,7 @@
             e.preventDefault();
             document.body.classList.remove("dnd");
 
-            htmlDirContent.getFilesFromDragEvent(e, true)
+            htmlDirContent.getFilesFromDragEvent(e, {recursive: true, withFullPath: true})
                 .then((files) => {
                     console.log("FILES !!!!!!!!!", files);
                 });


### PR DESCRIPTION
to the file generated when 'withFullPath' option is used.

this to help firefox code because FF converts "/" into ":" in the name prop

fixes #16 